### PR TITLE
Update the version number to 1.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 """Perform the package airflow-provider-lightup setup."""
 setup(


### PR DESCRIPTION
Update the version number to 1.0.2 for https://github.com/lightup-data/lightup-airflow-provider/pull/5